### PR TITLE
added a fix to accumulate multiple http query param

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -13,6 +13,7 @@ import type {
 	IRequestOptions,
 	IHttpRequestMethods,
 	ICredentialDataDecryptedObject,
+	GenericValue,
 } from 'n8n-workflow';
 import {
 	BINARY_ENCODING,
@@ -384,6 +385,20 @@ export class HttpRequestV3 implements INodeType {
 					});
 				}
 
+				const parametersToKeyValuQs = async(
+					accumulator: IDataObject,
+					cur: { name: string; value: string; parameterType?: string; inputDataFieldName?: string },
+				)=> {
+					if (accumulator[cur.name] && typeof accumulator[cur.name] === "string"){
+					    accumulator[cur.name] = [accumulator[cur.name], cur.value]
+				    } else if(accumulator[cur.name]){
+						(accumulator[cur.name] as GenericValue[])?.push(cur.value)					}
+					else {
+						accumulator[cur.name]=cur.value;
+					}
+					return accumulator
+				};
+
 				const parametersToKeyValue = async (
 					accumulator: { [key: string]: any },
 					cur: { name: string; value: string; parameterType?: string; inputDataFieldName?: string },
@@ -487,7 +502,7 @@ export class HttpRequestV3 implements INodeType {
 				// Get parameters defined in the UI
 				if (sendQuery && queryParameters) {
 					if (specifyQuery === 'keypair') {
-						requestOptions.qs = await reduceAsync(queryParameters, parametersToKeyValue);
+						requestOptions.qs = await reduceAsync(queryParameters, parametersToKeyValuQs);
 					} else if (specifyQuery === 'json') {
 						// query is specified using JSON
 						try {


### PR DESCRIPTION
## Summary
The PR fixes the HTTP Request Node and it ltes it send multiple query params with the same name

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved query parameter handling in key-pair mode, correctly supporting repeated keys and multiple values.
  - Ensures more accurate and consistent construction of request URLs from user-provided query parameters.
  - Reduces edge-case errors when assembling query strings, improving reliability across varied inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->